### PR TITLE
Fix linux detection

### DIFF
--- a/zImageOptimizer.sh
+++ b/zImageOptimizer.sh
@@ -90,7 +90,7 @@ installDeps()
 	PLATFORM="unknown"
 	PLATFORM_ARCH="unknown"
 	PLATFORM_SUPPORT=0
-	if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		PLATFORM="linux"
 		PLATFORM_DISTRIBUTION="unknown"
 		PLATFORM_VERSION="unknown"
@@ -901,7 +901,7 @@ checkDirLock()
 
 savePerms()
 {
-	if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 		CUR_OWNER=$(stat -c "%U:%G" "$IMAGE")
 		CUR_PERMS=$(stat -c "%a" "$IMAGE")
 	else


### PR DESCRIPTION
Linux wasn't detected correctly in my Raspberry Pi device as the returned string in ``OSTYPE`` is ``linux-gnueabihf`` instead of ``linux-gnu``

Removed also the author block as I saw that there are other contributions from other people throughout the commit history, so the authors of the code are not only you but also @Incrementing and @VarunBatraIT. People looking for the full history of contributions can directly check in https://github.com/zevilz/zImageOptimizer/graphs/contributors